### PR TITLE
Bug fix for problem with setting up passwordless ssh for root

### DIFF
--- a/starcluster/node.py
+++ b/starcluster/node.py
@@ -689,7 +689,7 @@ class Node(object):
                     log.warn("src and destination are the same: %s, skipping" %
                              remote_file)
                     continue
-                self.ssh.put(f.name, dest)
+                node.ssh.put(f.name, dest)
                 nrf = node.ssh.remote_file(dest, 'a')
                 nrf.chown(uid, gid)
                 nrf.chmod(mode)


### PR DESCRIPTION
I'd earlier mentioned that ssh'ing without a password from master -> a node wasn't working.   Finally dug in and found a the mistake in copy_remote_file_to_nodes.
