### PR TITLE
fix for bug where zone was not getting properly set when creating master

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -1089,6 +1089,8 @@ class Cluster(object):
                 log.info("Reverting to \"no zone\" as the min price is "
                          "above the spot bid.")
                 zone = None
+        elif zone is None:
+            zone = getattr(self.zone, 'name', None)
 
         image_id = image_id or self.node_image_id
         count = len(aliases) if not spot_bid else 1


### PR DESCRIPTION
Specifically, this can cause the master to get assigned to a different zone then the volumes mounted by the cluster (when volumes are specified).   (Which in turn causes cluster creation to fail.)
