### PR TITLE
Plugins were not being reread when modifying cluster

### DIFF
--- a/starcluster/cluster.py
+++ b/starcluster/cluster.py
@@ -420,7 +420,7 @@ class Cluster(object):
                  keyname=None,
                  key_location=None,
                  volumes=[],
-                 plugins=[],
+                 plugins=None,
                  permissions=[],
                  userdata_scripts=[],
                  refresh_interval=30,


### PR DESCRIPTION
I wonder why this would not have affected anyone else, but the test introduced in file starcluster/cluster.py by commit 26cc8ca.

The plugins member is being initialized to [] so the test failure when tested against '''None'''.

Feel free to reject this PR.
