### PR TITLE
Ubuntu 16.04 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pytest-flakes==0.2
 sphinx==1.2.1
 sphinxcontrib-issuetracker==0.11
 pudb==2013.5.1
+cryptography>=1.2.3


### PR DESCRIPTION
openssl 1.0.2g that's shipped with Ubuntu 16.04 breaks the cryptography package in versions older than 1.2.3 (https://github.com/pyca/cryptography/issues/2750). Updating the package version for cryptography in requirements.txt. This is backwards compatible with Ubuntu 14.04.
