### PR TITLE
Fix issue where a spot cluster cannot be started using starcluster start

### DIFF
--- a/starcluster/commands/start.py
+++ b/starcluster/commands/start.py
@@ -254,6 +254,7 @@ class CmdStart(ClusterCompleter):
             if interval is not None:
                 scluster.refresh_interval = interval
         if self.opts.spot_bid is not None and not self.opts.no_create:
+            scluster.node_instance_array[0]['spot_bid'] = self.opts.spot_bid
             msg = user_msgs.spotmsg % {'size': scluster.cluster_size,
                                        'tag': tag}
             if not validate_only and not create_only:


### PR DESCRIPTION
The spot bid value wasn't being set when passed from the starcluster start command (e.g. starcluster start -c smallcluster imagehost -s 2 -b 0.5). The node_instance_array is initiated before the Cluster class is updated with the additional options. Since spot_bid is now initialized within the node_instance_array and is retrieved via the spot_bid function,  the updated value of the spot_bid variable is never used on cluster initiation. 
