### PR TITLE
Allow aws_access_key_id and aws_secret_access_key to be left blank

### DIFF
--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -252,8 +252,8 @@ GLOBAL_SETTINGS = {
 }
 
 AWS_SETTINGS = {
-    'aws_access_key_id': (str, True, None, None, None),
-    'aws_secret_access_key': (str, True, None, None, None),
+    'aws_access_key_id': (str, False, None, None, None),
+    'aws_secret_access_key': (str, False, None, None, None),
     'aws_user_id': (str, False, None, None, None),
     'ec2_cert': (str, False, None, None, __expand_all),
     'ec2_private_key': (str, False, None, None, __expand_all),


### PR DESCRIPTION
boto will then employ it's own resolution mechanism allowing the user to specify in config file or env var.