### PR TITLE
Security token support

### DIFF
--- a/starcluster/awsutils.py
+++ b/starcluster/awsutils.py
@@ -99,7 +99,7 @@ class EasyAWS(object):
 
 class EasyEC2(EasyAWS):
     def __init__(self, aws_access_key_id, aws_secret_access_key,
-                 aws_ec2_path='/', aws_s3_host=None, aws_s3_path='/',
+                 aws_security_token=None, aws_ec2_path='/', aws_s3_host=None, aws_s3_path='/',
                  aws_port=None, aws_region_name=None, aws_is_secure=True,
                  aws_region_host=None, aws_proxy=None, aws_proxy_port=None,
                  aws_proxy_user=None, aws_proxy_pass=None,
@@ -112,7 +112,8 @@ class EasyEC2(EasyAWS):
                     path=aws_ec2_path, proxy=aws_proxy,
                     proxy_port=aws_proxy_port, proxy_user=aws_proxy_user,
                     proxy_pass=aws_proxy_pass,
-                    validate_certs=aws_validate_certs)
+                    validate_certs=aws_validate_certs,
+                    security_token=aws_security_token)
         super(EasyEC2, self).__init__(aws_access_key_id, aws_secret_access_key,
                                       boto.connect_vpc, **kwds)
         self._conn = kwargs.get('connection')
@@ -121,7 +122,8 @@ class EasyEC2(EasyAWS):
                     aws_proxy=aws_proxy, aws_proxy_port=aws_proxy_port,
                     aws_proxy_user=aws_proxy_user,
                     aws_proxy_pass=aws_proxy_pass,
-                    aws_validate_certs=aws_validate_certs)
+                    aws_validate_certs=aws_validate_certs,
+                    security_token=aws_security_token)
         self.s3 = EasyS3(aws_access_key_id, aws_secret_access_key, **kwds)
         self._regions = None
         self._account_attrs = None

--- a/starcluster/static.py
+++ b/starcluster/static.py
@@ -266,6 +266,7 @@ GLOBAL_SETTINGS = {
 AWS_SETTINGS = {
     'aws_access_key_id': (str, False, None, None, None),
     'aws_secret_access_key': (str, False, None, None, None),
+    'aws_security_token': (str, False, None, None, None),
     'aws_user_id': (str, False, None, None, None),
     'ec2_cert': (str, False, None, None, __expand_all),
     'ec2_private_key': (str, False, None, None, __expand_all),

--- a/starcluster/templates/config.py
+++ b/starcluster/templates/config.py
@@ -46,6 +46,8 @@ AWS_ACCESS_KEY_ID = #your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY = #your_secret_access_key
 # replace this with your account number
 AWS_USER_ID= #your userid
+# Uncomment to specify a STS security token (eg AWS Education session_token)  (OPTIONAL)
+#AWS_SECURITY_TOKEN = #your_security_token
 # Uncomment to specify a different Amazon AWS region  (OPTIONAL)
 # (defaults to us-east-1 if not specified)
 # NOTE: AMIs have to be migrated!


### PR DESCRIPTION
With the current configuration, it's impossible to use StarCluster with an AWS Education account.

I added the security token support: 
- In the  AWS initialization part
- In the parsing utility
- In the template.

(Credits to https://github.com/eedlund that posted original PR to the original StarCluster repo in 2014)